### PR TITLE
Added is-not-positive

### DIFF
--- a/src/Integer/IsPositive.hs
+++ b/src/Integer/IsPositive.hs
@@ -1,5 +1,7 @@
 module Integer.IsPositive (
    is_positive_integer
+ , is_not_positive_integer
 ) where
 
 is_positive_integer = (0 < )
+is_not_positive_integer = not . is_positive_integer


### PR DESCRIPTION
I'm not positive this is a positive addition to the `ispositive` library, since it introduces `is-not-positive`, but I'm positive we can work together to obtain peaceful resolution. Will version bump upon request.
